### PR TITLE
Fix silly mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Release
 cmake --build . --config Release
 ```
 
-Or download the pre-built binaries from the [v0.1.0 Release](https://github.com/YourUsername/YourRepoName/releases/tag/v0.1.0) page.
+Or download the latest pre-built binaries from the [Releases](https://github.com/EvickaStudio/decoy/releases/latest) page.
 
 ## Usage
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the README to point to the latest release page for downloading pre-built binaries.