### PR TITLE
Feat/decoy identifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,6 @@ project(decoy C)
 
 set(CMAKE_C_STANDARD 11)
 
-if(MSVC)
-    # Optimize for size and enable link-time code generation:
-    set(CMAKE_C_FLAGS_RELEASE "/O1 /GL /Gy /DNDEBUG")
-    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/LTCG /OPT:REF /OPT:ICF")
-endif()
-
 # Specify where to find headers and resources
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src")
 
@@ -26,6 +20,15 @@ add_executable(decoy-manager
     src/args.c
     resources/manager.rc
 )
+
+if(MSVC)
+    # Optimize for size and enable link-time code generation:
+    set(CMAKE_C_FLAGS_RELEASE "/O1 /GL /Gy /DNDEBUG")
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/LTCG /OPT:REF /OPT:ICF")
+    
+    # Link against Version.lib and Psapi.lib
+    target_link_libraries(decoy-manager PRIVATE Version.lib Psapi.lib)
+endif()
 
 # Ensure the executables end up in the same directory
 set_target_properties(dummy decoy-manager PROPERTIES

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Decoy is a lightweight tool that launches multiple dummy processes named after c
 - Non-interactive modes via command-line arguments
 - Useful for testing software/malware behavior in an environment that appears monitored or "add another layer of security" (not a substitute for proper security measures)
 
+## Safety
+
+Starting from the newer versions (not in v0.1.0), the dummy process includes an extra entry in the [dummy.rc](resources/dummy.rc) resource file:
+
+```plaintext
+VALUE "DecoyIdentifier", "0193b58d-cf59-703c-afda-a8c62c43f6b0\0"
+```
+
+This `DecoyIdentifier` with a unique UUID allows the manager to distinguish between the decoy processes it started and legitimate processes with the same name. Before terminating any process, the manager checks for this identifier in the process's version information. If the identifier matches, it proceeds to terminate the process; otherwise, it skips it to avoid interfering with legitimate applications.
+
 ## Example Process Names
 
 Decoy includes common tool names such as:

--- a/resources/dummy.rc
+++ b/resources/dummy.rc
@@ -7,18 +7,18 @@
  * This provides version information to the dummy executable.
  */
 
-1 VERSIONINFO
-FILEVERSION 1,0,0,0
-PRODUCTVERSION 1,0,0,0
-FILEFLAGSMASK 0x3fL
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 1,0,0,0
+ PRODUCTVERSION 1,0,0,0
+ FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
- FILEFLAGS VS_FF_DEBUG
+ FILEFLAGS 0x1L
 #else
  FILEFLAGS 0x0L
 #endif
-FILEOS VOS__WINDOWS32
-FILETYPE VFT_APP
-FILESUBTYPE VFT2_UNKNOWN
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
@@ -31,6 +31,7 @@ BEGIN
             VALUE "OriginalFilename", "dummy.exe\0"
             VALUE "ProductName", "Fake Analysis Suite\0"
             VALUE "ProductVersion", "1.0.0.0\0"
+	        VALUE "DecoyIdentifier", "0193b58d-cf59-703c-afda-a8c62c43f6b0\0" //UUID for identification
         END
     END
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -68,6 +68,7 @@ BOOL hasDecoyIdentifier(const char *exePath)
             }
         }
         free(verData);
+        return FALSE;
     }
     return FALSE;
 }
@@ -115,6 +116,10 @@ void killProcessByName(const char *pname)
                                 qprintf("[-] Failed to terminate %s (PID: %lu). Error: %lu\n", pname, pe.th32ProcessID, GetLastError());
                             }
                         }
+                    }
+                    else
+                    {
+                        qprintf("[-] GetModuleFileNameExA failed for PID: %lu. Error: %lu\n", pe.th32ProcessID, GetLastError());
                     }
                     CloseHandle(hProcess);
                 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -42,6 +42,37 @@ BOOL fileExists(const char *filename)
 }
 
 /**
+ * @brief Checks if a file has a specific version information.
+ *
+ * @param exePath The path to the executable.
+ * @return TRUE if the file has the DecoyIdentifier, FALSE otherwise.
+ */
+BOOL hasDecoyIdentifier(const char *exePath)
+{
+    DWORD verHandle = 0;
+    DWORD verSize = GetFileVersionInfoSizeA(exePath, &verHandle);
+    if (verSize > 0)
+    {
+        LPVOID verData = malloc(verSize);
+        if (GetFileVersionInfoA(exePath, verHandle, verSize, verData))
+        {
+            LPVOID lpBuffer = NULL;
+            UINT size = 0;
+            if (VerQueryValueA(verData, "\\StringFileInfo\\040904b0\\DecoyIdentifier", &lpBuffer, &size))
+            {
+                if (lpBuffer && strcmp((char *)lpBuffer, "0193b58d-cf59-703c-afda-a8c62c43f6b0") == 0)
+                {
+                    free(verData);
+                    return TRUE;
+                }
+            }
+        }
+        free(verData);
+    }
+    return FALSE;
+}
+
+/**
  * @brief Kills all processes by a given name.
  *
  * Uses a snapshot of system processes and compares against pname.
@@ -60,39 +91,40 @@ void killProcessByName(const char *pname)
     PROCESSENTRY32 pe;
     pe.dwSize = sizeof(pe);
 
-    if (!Process32First(hSnapshot, &pe))
+    if (Process32First(hSnapshot, &pe))
     {
-        qprintf("[-] Failed to retrieve first process. Error: %lu\n", GetLastError());
-        CloseHandle(hSnapshot);
-        return;
-    }
-
-    do
-    {
-        // Example of bounds checking for strings
-        if (strlen(pname) < MAX_PATH)
+        do
         {
-            // Safe usage of pname
-            if (_strnicmp(pe.szExeFile, pname, MAX_PATH) == 0)
+            if (_stricmp(pe.szExeFile, pname) == 0)
             {
-                HANDLE hProc = OpenProcess(PROCESS_TERMINATE, FALSE, pe.th32ProcessID);
-                if (hProc)
+                HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ | PROCESS_TERMINATE, FALSE, pe.th32ProcessID);
+                if (hProcess)
                 {
-                    if (!TerminateProcess(hProc, 0))
+                    char exePath[MAX_PATH];
+                    if (GetModuleFileNameExA(hProcess, NULL, exePath, MAX_PATH))
                     {
-                        qprintf("[-] Failed to terminate %s (PID: %lu). Error: %lu\n", pname, pe.th32ProcessID, GetLastError());
+                        if (hasDecoyIdentifier(exePath))
+                        {
+                            if (TerminateProcess(hProcess, 0))
+                            {
+                                WaitForSingleObject(hProcess, 2000);
+                                qprintf("[+] Terminated %s (PID: %lu)\n", pname, pe.th32ProcessID);
+                            }
+                            else
+                            {
+                                qprintf("[-] Failed to terminate %s (PID: %lu). Error: %lu\n", pname, pe.th32ProcessID, GetLastError());
+                            }
+                        }
                     }
-                    WaitForSingleObject(hProc, 2000);
-                    CloseHandle(hProc);
-                    qprintf("[+] %s (PID: %lu) has been terminated\n", pname, pe.th32ProcessID);
+                    CloseHandle(hProcess);
                 }
                 else
                 {
                     qprintf("[-] Cannot open process %s (PID: %lu). Error: %lu\n", pname, pe.th32ProcessID, GetLastError());
                 }
             }
-        }
-    } while (Process32Next(hSnapshot, &pe));
+        } while (Process32Next(hSnapshot, &pe));
+    }
 
     CloseHandle(hSnapshot);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -25,6 +25,14 @@ void qprintf(const char *fmt, ...);
 BOOL fileExists(const char *filename);
 
 /**
+ * @brief Checks if a file has a specific version information.
+ *
+ * @param exePath The path to the executable.
+ * @return TRUE if the file has the DecoyIdentifier, FALSE otherwise.
+ */
+BOOL hasDecoyIdentifier(const char *exePath);
+
+/**
  * @brief Kills all running instances of processes with a given name.
  *
  * @param pname Process name (e.g. "procmon.exe")


### PR DESCRIPTION
## Summary by Sourcery

Add a new feature to identify and terminate only decoy processes by checking for a specific 'DecoyIdentifier' in the process's version information. Update build configuration to include necessary libraries and document the new feature in the README.

New Features:
- Introduce a new function 'hasDecoyIdentifier' to check for a specific version information in executable files.

Enhancements:
- Modify the 'killProcessByName' function to check for a 'DecoyIdentifier' before terminating processes, ensuring only decoy processes are terminated.

Build:
- Update CMakeLists.txt to link against Version.lib and Psapi.lib when using MSVC.

Documentation:
- Add documentation in README.md about the new 'DecoyIdentifier' feature, explaining its purpose and usage.